### PR TITLE
Refresh market data of quote test cases

### DIFF
--- a/test/testQuote.cpp
+++ b/test/testQuote.cpp
@@ -8,7 +8,7 @@
 BOOST_AUTO_TEST_CASE(TestGetHistoricalCsv) {
     // S&P 500
     Quote *quote = new Quote("^GSPC");
-    std::time_t epoch = dateToEpoch("2017-12-01") + 72000;
+    std::time_t epoch = dateToEpoch("2020-12-01") + 72000;
     std::string csv = quote->getHistoricalCsv(epoch, epoch, "1d");
 
     // Test the two CSV lines
@@ -20,66 +20,45 @@ BOOST_AUTO_TEST_CASE(TestGetHistoricalCsv) {
     BOOST_CHECK_EQUAL(expected, line);
 
     std::getline(csvStream, line);
-    expected = "2017-12-01,2645.100098,2650.620117,2605.520020,2642.219971,2642.219971,3942320000";
+    expected = "2020-12-01,3645.870117,3678.449951,3645.870117,3662.449951,3662.449951,5403660000";
     BOOST_CHECK_EQUAL(expected, line);
 }
 
 BOOST_AUTO_TEST_CASE(TestGetHistoricalSpots) {
     // Euro Stoxx 50
     Quote *quote = new Quote("^STOXX50E");
-    quote->getHistoricalSpots("2017-12-01", "2017-12-04", "1d");
+    quote->getHistoricalSpots("2020-12-01", "2020-12-02", "1d");
 
-    // Test the spot at 2017-12-01
-    Spot spot = quote->getSpot("2017-12-01");
-    BOOST_CHECK_CLOSE(3527.550049, spot.getOpen(), 0.001f);
-    BOOST_CHECK_CLOSE(3527.550049, spot.getHigh(), 0.001f);
-    BOOST_CHECK_CLOSE(3527.550049, spot.getLow(), 0.001f);
-    BOOST_CHECK_CLOSE(3527.550049, spot.getClose(), 0.001f);
-
-    // Test the spot at 2017-12-04
-    spot = quote->getSpot("2017-12-04");
-    BOOST_CHECK_CLOSE(3576.219971, spot.getOpen(), 0.001f);
-    BOOST_CHECK_CLOSE(3576.219971, spot.getHigh(), 0.001f);
-    BOOST_CHECK_CLOSE(3576.219971, spot.getLow(), 0.001f);
-    BOOST_CHECK_CLOSE(3576.219971, spot.getClose(), 0.001f);
+    // Test the spot at 2020-12-01
+    Spot spot = quote->getSpot("2020-12-01");
+    BOOST_CHECK_CLOSE(3499.280029, spot.getOpen(), 0.001f);
+    BOOST_CHECK_CLOSE(3532.909912, spot.getHigh(), 0.001f);
+    BOOST_CHECK_CLOSE(3499.280029, spot.getLow(), 0.001f);
+    BOOST_CHECK_CLOSE(3525.239990, spot.getClose(), 0.001f);
 }
 
 BOOST_AUTO_TEST_CASE(TestEurUsd) {
     // EUR/USD rate
     Quote *quote = new Quote("EURUSD=X");
-    quote->getHistoricalSpots("2017-12-01", "2017-12-31", "1d");
+    quote->getHistoricalSpots("2020-12-01", "2020-12-02", "1d");
 
-    // Test the spot at 2017-12-08
-    Spot spot = quote->getSpot("2017-12-08");
-    BOOST_CHECK_CLOSE(1.17744, spot.getOpen(), 0.001f);
-    BOOST_CHECK_CLOSE(1.17772, spot.getHigh(), 0.001f);
-    BOOST_CHECK_CLOSE(1.17319, spot.getLow(), 0.001f);
-    BOOST_CHECK_CLOSE(1.17722, spot.getClose(), 0.001f);
-
-    // Test the spot at 2017-12-21
-    spot = quote->getSpot("2017-12-21");
-    BOOST_CHECK_CLOSE(1.18778, spot.getOpen(), 0.001f);
-    BOOST_CHECK_CLOSE(1.1892, spot.getHigh(), 0.001f);
-    BOOST_CHECK_CLOSE(1.18502, spot.getLow(), 0.001f);
-    BOOST_CHECK_CLOSE(1.18782, spot.getClose(), 0.001f);
+    // Test the spot at 2020-12-01
+    Spot spot = quote->getSpot("2020-12-01");
+    BOOST_CHECK_CLOSE(1.193773, spot.getOpen(), 0.001f);
+    BOOST_CHECK_CLOSE(1.205357, spot.getHigh(), 0.001f);
+    BOOST_CHECK_CLOSE(1.193599, spot.getLow(), 0.001f);
+    BOOST_CHECK_CLOSE(1.193816, spot.getClose(), 0.001f);
 }
 
 BOOST_AUTO_TEST_CASE(TestEurAud) {
     // EUR/AUD rate
     Quote *quote = new Quote("EURAUD=X");
-    quote->getHistoricalSpots("2017-12-01", "2017-12-31", "1d");
+    quote->getHistoricalSpots("2020-12-01", "2020-12-02", "1d");
 
-    // Test the spot at 2017-12-13
-    Spot spot = quote->getSpot("2017-12-13");
-    BOOST_CHECK_CLOSE(1.553756, spot.getOpen(), 0.001f);
-    BOOST_CHECK_CLOSE(1.552764, spot.getHigh(), 0.001f);
-    BOOST_CHECK_CLOSE(1.545433, spot.getLow(), 0.001f);
-    BOOST_CHECK_CLOSE(1.553957, spot.getClose(), 0.001f);
-
-    // Test the spot at 2017-12-27
-    spot = quote->getSpot("2017-12-27");
-    BOOST_CHECK_CLOSE(1.534314, spot.getOpen(), 0.001f);
-    BOOST_CHECK_CLOSE(1.533646, spot.getHigh(), 0.001f);
-    BOOST_CHECK_CLOSE(1.531682, spot.getLow(), 0.001f);
-    BOOST_CHECK_CLOSE(1.533925, spot.getClose(), 0.001f);
+    // Test the spot at 2020-12-01
+    Spot spot = quote->getSpot("2020-12-01");
+    BOOST_CHECK_CLOSE(1.622020, spot.getOpen(), 0.001f);
+    BOOST_CHECK_CLOSE(1.637390, spot.getHigh(), 0.001f);
+    BOOST_CHECK_CLOSE(1.621700, spot.getLow(), 0.001f);
+    BOOST_CHECK_CLOSE(1.622550, spot.getClose(), 0.001f);
 }


### PR DESCRIPTION
Market data in test cases is very old (from 2017) and for some reason it fails when trying to get back from Yahoo Finance.

Here we update all spot dates to 2020-12-01.