### PR TITLE
Replace boost with gtest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ CMakeLists.txt.user
 
 # Build directory
 build/
+
+# IDE settings
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,27 +1,23 @@
-cmake_minimum_required (VERSION 3.6.3)
-project (yahoo-finance CXX)
+cmake_minimum_required(VERSION 3.6.3)
+project(yahoo-finance CXX)
 
 # Enable C+11
-set (CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 11)
 
 # Library source files
-file (GLOB LIB_SOURCES src/*.cpp)
-file (GLOB LIB_HEADERS src/*.hpp )
-add_library (yahoo-finance ${LIB_SOURCES} ${LIB_HEADERS})
+file(GLOB LIB_SOURCES src/*.cpp)
+file(GLOB LIB_HEADERS src/*.hpp )
+add_library(yahoo-finance ${LIB_SOURCES} ${LIB_HEADERS})
 
-# Example executable
-add_executable (example src/example.cpp)
-target_link_libraries (example yahoo-finance curl)
+# Build documentation
+add_subdirectory(doc)
 
-# Test
-add_subdirectory (test)
-enable_testing ()
-add_test (NAME TimeUtilsTest
-    COMMAND testTimeUtils
-    )
-add_test (NAME QuoteTest
-    COMMAND testQuote
-    )
+# Create example executable
+add_executable(example src/example.cpp)
+target_link_libraries(example yahoo-finance curl)
 
-# Documentation
-add_subdirectory (doc)
+# Build tests
+add_subdirectory(test)
+enable_testing()
+add_test(NAME TimeUtilsTest COMMAND testTimeUtils)
+add_test(NAME QuoteTest COMMAND testQuote)

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ C++ library to get stock data from Yahoo Finance.
 
 ## Dependencies
 
-- cmake >= 3.6.1
-- boost
+- cmake >= 3.6.3
 - curl
 
 ## Build

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,29 +1,34 @@
-############### Boost Unit Tests #################
+# Download and unpack googletest at configure time
+configure_file(gtest/CMakeLists.txt googletest-download/CMakeLists.txt)
+execute_process(
+    COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+    RESULT_VARIABLE result
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+if(result)
+    message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+endif()
+execute_process(
+    COMMAND ${CMAKE_COMMAND} --build .
+    RESULT_VARIABLE result
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+if(result)
+    message(FATAL_ERROR "Build step for googletest failed: ${result}")
+endif()
 
-find_package (Boost COMPONENTS system filesystem unit_test_framework REQUIRED)
+# Add googletest directly to our build. This defines
+# the gtest and gtest_main targets.
+add_subdirectory(
+    ${CMAKE_CURRENT_BINARY_DIR}/googletest-src
+    ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
+    EXCLUDE_FROM_ALL
+)
 
-include_directories (${CMAKE_SOURCE_DIR}/src
-    ${Boost_INCLUDE_DIRS}
-    )
+# Include sources directory
+include_directories(${CMAKE_SOURCE_DIR}/src)
 
-add_definitions (-DBOOST_TEST_DYN_LINK)
+# Create test executables
+add_executable(testTimeUtils testTimeUtils.cpp)
+target_link_libraries(testTimeUtils yahoo-finance curl gtest_main)
 
-# Executables
-
-add_executable (testTimeUtils testTimeUtils.cpp)
-target_link_libraries (testTimeUtils
-    yahoo-finance
-    curl
-    ${Boost_FILESYSTEM_LIBRARY}
-    ${Boost_SYSTEM_LIBRARY}
-    ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
-    )
-
-add_executable (testQuote testQuote.cpp)
-target_link_libraries (testQuote
-    yahoo-finance
-    curl
-    ${Boost_FILESYSTEM_LIBRARY}
-    ${Boost_SYSTEM_LIBRARY}
-    ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
-    )
+add_executable(testQuote testQuote.cpp)
+target_link_libraries(testQuote yahoo-finance curl gtest_main)

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -1,0 +1,13 @@
+project(googletest-download NONE)
+
+include(ExternalProject)
+ExternalProject_Add(googletest
+    GIT_REPOSITORY      https://github.com/google/googletest.git
+    GIT_TAG             master
+    SOURCE_DIR          "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+    BINARY_DIR          "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
+    CONFIGURE_COMMAND   ""
+    BUILD_COMMAND       ""
+    INSTALL_COMMAND     ""
+    TEST_COMMAND        ""
+)

--- a/test/testQuote.cpp
+++ b/test/testQuote.cpp
@@ -1,11 +1,8 @@
-#define BOOST_TEST_MODULE QuoteTest
-#include <boost/test/unit_test.hpp>
-
+#include "gtest/gtest.h"
 #include "quote.hpp"
 #include "time_utils.hpp"
 
-
-BOOST_AUTO_TEST_CASE(TestGetHistoricalCsv) {
+TEST(Quote, TestGetHistoricalCsv) {
     // S&P 500
     Quote *quote = new Quote("^GSPC");
     std::time_t epoch = dateToEpoch("2020-12-01") + 72000;
@@ -17,48 +14,53 @@ BOOST_AUTO_TEST_CASE(TestGetHistoricalCsv) {
 
     std::getline(csvStream, line);
     expected = "Date,Open,High,Low,Close,Adj Close,Volume";
-    BOOST_CHECK_EQUAL(expected, line);
+    EXPECT_EQ(expected, line);
 
     std::getline(csvStream, line);
     expected = "2020-12-01,3645.870117,3678.449951,3645.870117,3662.449951,3662.449951,5403660000";
-    BOOST_CHECK_EQUAL(expected, line);
+    EXPECT_EQ(expected, line);
 }
 
-BOOST_AUTO_TEST_CASE(TestGetHistoricalSpots) {
+TEST(Quote, TestGetHistoricalSpots) {
     // Euro Stoxx 50
     Quote *quote = new Quote("^STOXX50E");
     quote->getHistoricalSpots("2020-12-01", "2020-12-02", "1d");
 
     // Test the spot at 2020-12-01
     Spot spot = quote->getSpot("2020-12-01");
-    BOOST_CHECK_CLOSE(3499.280029, spot.getOpen(), 0.001f);
-    BOOST_CHECK_CLOSE(3532.909912, spot.getHigh(), 0.001f);
-    BOOST_CHECK_CLOSE(3499.280029, spot.getLow(), 0.001f);
-    BOOST_CHECK_CLOSE(3525.239990, spot.getClose(), 0.001f);
+    EXPECT_NEAR(3499.280029, spot.getOpen(), 0.001f);
+    EXPECT_NEAR(3532.909912, spot.getHigh(), 0.001f);
+    EXPECT_NEAR(3499.280029, spot.getLow(), 0.001f);
+    EXPECT_NEAR(3525.239990, spot.getClose(), 0.001f);
 }
 
-BOOST_AUTO_TEST_CASE(TestEurUsd) {
+TEST(Quote, TestEurUsd) {
     // EUR/USD rate
     Quote *quote = new Quote("EURUSD=X");
     quote->getHistoricalSpots("2020-12-01", "2020-12-02", "1d");
 
     // Test the spot at 2020-12-01
     Spot spot = quote->getSpot("2020-12-01");
-    BOOST_CHECK_CLOSE(1.193773, spot.getOpen(), 0.001f);
-    BOOST_CHECK_CLOSE(1.205357, spot.getHigh(), 0.001f);
-    BOOST_CHECK_CLOSE(1.193599, spot.getLow(), 0.001f);
-    BOOST_CHECK_CLOSE(1.193816, spot.getClose(), 0.001f);
+    EXPECT_NEAR(1.193773, spot.getOpen(), 0.001f);
+    EXPECT_NEAR(1.205357, spot.getHigh(), 0.001f);
+    EXPECT_NEAR(1.193599, spot.getLow(), 0.001f);
+    EXPECT_NEAR(1.193816, spot.getClose(), 0.001f);
 }
 
-BOOST_AUTO_TEST_CASE(TestEurAud) {
+TEST(Quote, TestEurAud) {
     // EUR/AUD rate
     Quote *quote = new Quote("EURAUD=X");
     quote->getHistoricalSpots("2020-12-01", "2020-12-02", "1d");
 
     // Test the spot at 2020-12-01
     Spot spot = quote->getSpot("2020-12-01");
-    BOOST_CHECK_CLOSE(1.622020, spot.getOpen(), 0.001f);
-    BOOST_CHECK_CLOSE(1.637390, spot.getHigh(), 0.001f);
-    BOOST_CHECK_CLOSE(1.621700, spot.getLow(), 0.001f);
-    BOOST_CHECK_CLOSE(1.622550, spot.getClose(), 0.001f);
+    EXPECT_NEAR(1.622020, spot.getOpen(), 0.001f);
+    EXPECT_NEAR(1.637390, spot.getHigh(), 0.001f);
+    EXPECT_NEAR(1.621700, spot.getLow(), 0.001f);
+    EXPECT_NEAR(1.622550, spot.getClose(), 0.001f);
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }

--- a/test/testTimeUtils.cpp
+++ b/test/testTimeUtils.cpp
@@ -1,22 +1,25 @@
-#define BOOST_TEST_MODULE TimeUtilsTest
-#include <boost/test/unit_test.hpp>
-
+#include "gtest/gtest.h"
 #include "time_utils.hpp"
 
-BOOST_AUTO_TEST_CASE(TestDateToEpoch) {
-    BOOST_CHECK_EQUAL(1428451200, dateToEpoch("2015-04-08"));
-    BOOST_CHECK_EQUAL(1441929600, dateToEpoch("2015-09-11"));
-    BOOST_CHECK_EQUAL(1468627200, dateToEpoch("2016-07-16"));
-    BOOST_CHECK_EQUAL(1483142400, dateToEpoch("2016-12-31"));
-    BOOST_CHECK_EQUAL(1520380800, dateToEpoch("2018-03-07"));
-    BOOST_CHECK_EQUAL(1681516800, dateToEpoch("2023-04-15"));
+TEST(TimeUtils, TestDateToEpoch) {
+    EXPECT_EQ(1428451200, dateToEpoch("2015-04-08"));
+    EXPECT_EQ(1441929600, dateToEpoch("2015-09-11"));
+    EXPECT_EQ(1468627200, dateToEpoch("2016-07-16"));
+    EXPECT_EQ(1483142400, dateToEpoch("2016-12-31"));
+    EXPECT_EQ(1520380800, dateToEpoch("2018-03-07"));
+    EXPECT_EQ(1681516800, dateToEpoch("2023-04-15"));
 }
 
-BOOST_AUTO_TEST_CASE(TestEpochToDate) {
-    BOOST_CHECK_EQUAL("2015-04-15", epochToDate(1429056000));
-    BOOST_CHECK_EQUAL("2016-02-29", epochToDate(1456704000));
-    BOOST_CHECK_EQUAL("2017-01-01", epochToDate(1483228800));
-    BOOST_CHECK_EQUAL("2017-03-03", epochToDate(1488499200));
-    BOOST_CHECK_EQUAL("2017-06-21", epochToDate(1498003200));
-    BOOST_CHECK_EQUAL("2022-11-07", epochToDate(1667779200));
+TEST(TimeUtils, TestEpochToDate) {
+    EXPECT_EQ("2015-04-15", epochToDate(1429056000));
+    EXPECT_EQ("2016-02-29", epochToDate(1456704000));
+    EXPECT_EQ("2017-01-01", epochToDate(1483228800));
+    EXPECT_EQ("2017-03-03", epochToDate(1488499200));
+    EXPECT_EQ("2017-06-21", epochToDate(1498003200));
+    EXPECT_EQ("2022-11-07", epochToDate(1667779200));
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Remove boost from dependencies and use [gtest](https://github.com/google/googletest) instead to run test cases.
We add gtest as an external CMake project so it'll be installed automatically before building the source code.
