### PR TITLE
ci: update ubuntu to v22.04

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,7 +14,9 @@ jobs:
 
     - name: Install libcurl
       # Project requires libcurl so we need to install it before building
-      run: sudo apt-get install libcurl4-openssl-dev
+      run: |
+        sudo apt-get update
+        sudo apt-get install libcurl4-openssl-dev
 
     - name: Create Build Environment
       run: cmake -E make_directory ${{github.workspace}}/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Update the version of Ubuntu to LTS 22.04 used in the workflow since 18.04 is deprecated.